### PR TITLE
Update ruff linter formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,32 +6,13 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.10
     hooks:
-      - id: flake8
-        name: Check PEP8
-        args: [--max-line-length=120, "--ignore=E121,E123,E126,E203,E226,E24,E704,W503,W504", "--per-file-ignores=__init__.py:F401"]
-
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
-        args: [--line-length=100]
-        name: Format code
+      - id: ruff
+        name: Ruff linting
+        args: [--fix, --exit-non-zero-on-fix]
         exclude: docs/source-app
-
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.13.0
-    hooks:
-      - id: blacken-docs
-        args: [--line-length=120]
-        additional_dependencies: [black==23.1.0]
+      - id: ruff-format
+        name: Ruff formatting
         exclude: docs/source-app
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: Format imports
-        args: [--profile=black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ imageio
 click
 rich
 pre-commit
+ruff
 pytest
 jax
 chex

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -4,6 +4,7 @@ imageio
 click
 rich
 pre-commit
+ruff
 pytest
 jax[cuda12]==0.7.2 # over 0.8.0 has some issues with the GPU
 chex

--- a/requirements_tpu.txt
+++ b/requirements_tpu.txt
@@ -5,6 +5,7 @@ imageio
 click
 rich
 pre-commit
+ruff
 pytest
 jax[tpu]
 chex

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,45 @@
+# Ruff configuration file
+# Replaces flake8, black, and isort
+
+# Line length for formatting (matching black's --line-length=100)
+line-length = 100
+
+# Target Python version
+target-version = "py39"
+
+# Enable import sorting (replaces isort)
+[lint.isort]
+known-first-party = []
+
+# Linting rules
+[lint]
+# Select all rules except those we want to ignore
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "N",   # pep8-naming
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "PIE", # flake8-pie
+    "SIM", # flake8-simplify
+]
+
+# Ignore rules that match previous flake8 configuration
+ignore = [
+    "E121",  # continuation line indentation
+    "E123",  # closing bracket indentation
+    "E126",  # continuation line over-indented
+    "E203",  # whitespace before ':'
+    "E226",  # missing whitespace around arithmetic operator
+    "E24",   # whitespace around ':' (covered by E203, E226)
+    "E704",  # multiple statements on one line (def)
+    "W503",  # line break before binary operator
+    "W504",  # line break after binary operator
+]
+
+# Per-file ignores
+[lint.per-file-ignores]
+"__init__.py" = ["F401"]  # unused imports (matching flake8 --per-file-ignores)


### PR DESCRIPTION
Migrate all pre-commit linters and formatters to Ruff for a unified and efficient code quality toolchain.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca2e72fd-213b-4b0e-8e99-00deffc8341d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca2e72fd-213b-4b0e-8e99-00deffc8341d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrate linting/formatting to Ruff via pre-commit, add Ruff config, and include Ruff in requirements.
> 
> - **Tooling**:
>   - **Pre-commit**: Replace `flake8`, `black`, and `isort` hooks with `ruff` and `ruff-format` in `.pre-commit-config.yaml`; keep core `pre-commit-hooks`.
>   - **Configuration**: Add `ruff.toml` defining line length, target Python version, isort settings, selected/ignored rules, and per-file ignores.
>   - **Dependencies**: Add `ruff` to `requirements.txt`, `requirements_gpu.txt`, and `requirements_tpu.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c0757640b23d127d1da8833d85e9f3d5b01bb3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->