### PR TITLE
Feature/add aqt quant

### DIFF
--- a/cli/benchmark_commands.py
+++ b/cli/benchmark_commands.py
@@ -44,6 +44,7 @@ def _load_benchmark_heuristic(
     benchmark_bundle,
     param_path: Optional[str],
     model_type: str = "default",
+    aqt_cfg: Optional[str] = None,
 ) -> Heuristic:
     heuristic_configs = benchmark_bundle.heuristic_nn_configs
     if heuristic_configs is None:
@@ -65,6 +66,8 @@ def _load_benchmark_heuristic(
 
     resolved_param_path = _resolve_param_path(path_template, puzzle, param_path)
     neural_config = {}
+    if aqt_cfg:
+        neural_config["aqt_cfg"] = aqt_cfg
 
     solver = heuristic_config.callable(
         puzzle=puzzle,
@@ -72,7 +75,12 @@ def _load_benchmark_heuristic(
         init_params=False,
         **neural_config,
     )
-    attach_runtime_metadata(solver, model_type=model_type, param_path=resolved_param_path)
+    attach_runtime_metadata(
+        solver,
+        model_type=model_type,
+        param_path=resolved_param_path,
+        extra={"aqt_cfg": aqt_cfg},
+    )
     return solver
 
 
@@ -82,6 +90,7 @@ def _load_benchmark_qfunction(
     benchmark_bundle,
     param_path: Optional[str],
     model_type: str = "default",
+    aqt_cfg: Optional[str] = None,
 ) -> QFunction:
     q_configs = benchmark_bundle.q_function_nn_configs
     if q_configs is None:
@@ -103,6 +112,8 @@ def _load_benchmark_qfunction(
 
     resolved_param_path = _resolve_param_path(path_template, puzzle, param_path)
     neural_config = {}
+    if aqt_cfg:
+        neural_config["aqt_cfg"] = aqt_cfg
 
     solver = q_config.callable(
         puzzle=puzzle,
@@ -110,7 +121,12 @@ def _load_benchmark_qfunction(
         init_params=False,
         **neural_config,
     )
-    attach_runtime_metadata(solver, model_type=model_type, param_path=resolved_param_path)
+    attach_runtime_metadata(
+        solver,
+        model_type=model_type,
+        param_path=resolved_param_path,
+        extra={"aqt_cfg": aqt_cfg},
+    )
     return solver
 
 
@@ -167,6 +183,13 @@ def _run_benchmark(
     help="Type of the heuristic model (default: 'default').",
 )
 @click.option(
+    "-q",
+    "--use-quantize",
+    is_flag=True,
+    default=False,
+    help="Use quantization (int8).",
+)
+@click.option(
     "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
@@ -181,11 +204,13 @@ def benchmark_astar(
     benchmark_cli_options,
     param_path: Optional[str],
     model_type: str,
+    use_quantize: bool,
     output_dir: Optional[Path],
     **kwargs,
 ):
+    aqt_cfg = "int8" if use_quantize else None
     solver = _load_benchmark_heuristic(
-        puzzle, benchmark_name, benchmark_bundle, param_path, model_type
+        puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
     puzzle_opts = PuzzleOptions(puzzle=benchmark_name)
     _run_benchmark(
@@ -221,6 +246,13 @@ def benchmark_astar(
     help="Type of the heuristic model (default: 'default').",
 )
 @click.option(
+    "-q",
+    "--use-quantize",
+    is_flag=True,
+    default=False,
+    help="Use quantization (int8).",
+)
+@click.option(
     "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
@@ -235,11 +267,13 @@ def benchmark_astar_d(
     benchmark_cli_options,
     param_path: Optional[str],
     model_type: str,
+    use_quantize: bool,
     output_dir: Optional[Path],
     **kwargs,
 ):
+    aqt_cfg = "int8" if use_quantize else None
     solver = _load_benchmark_heuristic(
-        puzzle, benchmark_name, benchmark_bundle, param_path, model_type
+        puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
     puzzle_opts = PuzzleOptions(puzzle=benchmark_name)
     _run_benchmark(
@@ -275,6 +309,13 @@ def benchmark_astar_d(
     help="Type of the Q-function model (default: 'default').",
 )
 @click.option(
+    "-q",
+    "--use-quantize",
+    is_flag=True,
+    default=False,
+    help="Use quantization (int8).",
+)
+@click.option(
     "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
@@ -289,11 +330,13 @@ def benchmark_qstar(
     benchmark_cli_options,
     param_path: Optional[str],
     model_type: str,
+    use_quantize: bool,
     output_dir: Optional[Path],
     **kwargs,
 ):
+    aqt_cfg = "int8" if use_quantize else None
     solver = _load_benchmark_qfunction(
-        puzzle, benchmark_name, benchmark_bundle, param_path, model_type
+        puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
     puzzle_opts = PuzzleOptions(puzzle=benchmark_name)
     _run_benchmark(
@@ -329,6 +372,13 @@ def benchmark_qstar(
     help="Type of the heuristic model (default: 'default').",
 )
 @click.option(
+    "-q",
+    "--use-quantize",
+    is_flag=True,
+    default=False,
+    help="Use quantization (int8).",
+)
+@click.option(
     "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
@@ -343,11 +393,13 @@ def benchmark_beam(
     benchmark_cli_options,
     param_path: Optional[str],
     model_type: str,
+    use_quantize: bool,
     output_dir: Optional[Path],
     **kwargs,
 ):
+    aqt_cfg = "int8" if use_quantize else None
     solver = _load_benchmark_heuristic(
-        puzzle, benchmark_name, benchmark_bundle, param_path, model_type
+        puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
     puzzle_opts = PuzzleOptions(puzzle=benchmark_name)
     _run_benchmark(
@@ -383,6 +435,13 @@ def benchmark_beam(
     help="Type of the Q-function model (default: 'default').",
 )
 @click.option(
+    "-q",
+    "--use-quantize",
+    is_flag=True,
+    default=False,
+    help="Use quantization (int8).",
+)
+@click.option(
     "--output-dir",
     type=click.Path(path_type=Path),
     default=None,
@@ -397,11 +456,13 @@ def benchmark_qbeam(
     benchmark_cli_options,
     param_path: Optional[str],
     model_type: str,
+    use_quantize: bool,
     output_dir: Optional[Path],
     **kwargs,
 ):
+    aqt_cfg = "int8" if use_quantize else None
     solver = _load_benchmark_qfunction(
-        puzzle, benchmark_name, benchmark_bundle, param_path, model_type
+        puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
     puzzle_opts = PuzzleOptions(puzzle=benchmark_name)
     _run_benchmark(

--- a/cli/benchmark_commands.py
+++ b/cli/benchmark_commands.py
@@ -187,7 +187,13 @@ def _run_benchmark(
     "--use-quantize",
     is_flag=True,
     default=False,
-    help="Use quantization (int8).",
+    help="Use quantization (defaults to int8).",
+)
+@click.option(
+    "--quant-type",
+    type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+    default="int8",
+    help="Specific AQT quantization configuration to use.",
 )
 @click.option(
     "--output-dir",
@@ -205,10 +211,11 @@ def benchmark_astar(
     param_path: Optional[str],
     model_type: str,
     use_quantize: bool,
+    quant_type: str,
     output_dir: Optional[Path],
     **kwargs,
 ):
-    aqt_cfg = "int8" if use_quantize else None
+    aqt_cfg = quant_type if use_quantize else None
     solver = _load_benchmark_heuristic(
         puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
@@ -250,7 +257,13 @@ def benchmark_astar(
     "--use-quantize",
     is_flag=True,
     default=False,
-    help="Use quantization (int8).",
+    help="Use quantization (defaults to int8).",
+)
+@click.option(
+    "--quant-type",
+    type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+    default="int8",
+    help="Specific AQT quantization configuration to use.",
 )
 @click.option(
     "--output-dir",
@@ -268,10 +281,11 @@ def benchmark_astar_d(
     param_path: Optional[str],
     model_type: str,
     use_quantize: bool,
+    quant_type: str,
     output_dir: Optional[Path],
     **kwargs,
 ):
-    aqt_cfg = "int8" if use_quantize else None
+    aqt_cfg = quant_type if use_quantize else None
     solver = _load_benchmark_heuristic(
         puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
@@ -313,7 +327,13 @@ def benchmark_astar_d(
     "--use-quantize",
     is_flag=True,
     default=False,
-    help="Use quantization (int8).",
+    help="Use quantization (defaults to int8).",
+)
+@click.option(
+    "--quant-type",
+    type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+    default="int8",
+    help="Specific AQT quantization configuration to use.",
 )
 @click.option(
     "--output-dir",
@@ -331,10 +351,11 @@ def benchmark_qstar(
     param_path: Optional[str],
     model_type: str,
     use_quantize: bool,
+    quant_type: str,
     output_dir: Optional[Path],
     **kwargs,
 ):
-    aqt_cfg = "int8" if use_quantize else None
+    aqt_cfg = quant_type if use_quantize else None
     solver = _load_benchmark_qfunction(
         puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
@@ -376,7 +397,13 @@ def benchmark_qstar(
     "--use-quantize",
     is_flag=True,
     default=False,
-    help="Use quantization (int8).",
+    help="Use quantization (defaults to int8).",
+)
+@click.option(
+    "--quant-type",
+    type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+    default="int8",
+    help="Specific AQT quantization configuration to use.",
 )
 @click.option(
     "--output-dir",
@@ -394,10 +421,11 @@ def benchmark_beam(
     param_path: Optional[str],
     model_type: str,
     use_quantize: bool,
+    quant_type: str,
     output_dir: Optional[Path],
     **kwargs,
 ):
-    aqt_cfg = "int8" if use_quantize else None
+    aqt_cfg = quant_type if use_quantize else None
     solver = _load_benchmark_heuristic(
         puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )
@@ -439,7 +467,13 @@ def benchmark_beam(
     "--use-quantize",
     is_flag=True,
     default=False,
-    help="Use quantization (int8).",
+    help="Use quantization (defaults to int8).",
+)
+@click.option(
+    "--quant-type",
+    type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+    default="int8",
+    help="Specific AQT quantization configuration to use.",
 )
 @click.option(
     "--output-dir",
@@ -457,10 +491,11 @@ def benchmark_qbeam(
     param_path: Optional[str],
     model_type: str,
     use_quantize: bool,
+    quant_type: str,
     output_dir: Optional[Path],
     **kwargs,
 ):
-    aqt_cfg = "int8" if use_quantize else None
+    aqt_cfg = quant_type if use_quantize else None
     solver = _load_benchmark_qfunction(
         puzzle, benchmark_name, benchmark_bundle, param_path, model_type, aqt_cfg=aqt_cfg
     )

--- a/cli/options.py
+++ b/cli/options.py
@@ -433,14 +433,21 @@ def heuristic_options(func: callable) -> callable:
         "--use-quantize",
         is_flag=True,
         default=False,
-        help="Use quantization (int8).",
+        help="Use quantization (defaults to int8).",
+    )
+    @click.option(
+        "--quant-type",
+        type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+        default="int8",
+        help="Specific AQT quantization configuration to use.",
     )
     @wraps(func)
     def wrapper(*args, **kwargs):
         heuristic_kwargs = map_kwargs_to_pydantic(HeuristicOptions, kwargs)
         heuristic_opts = HeuristicOptions(**heuristic_kwargs)
         use_quantize = kwargs.pop("use_quantize")
-        aqt_cfg = "int8" if use_quantize else None
+        quant_type = kwargs.pop("quant_type")
+        aqt_cfg = quant_type if use_quantize else None
 
         puzzle_bundle = kwargs.pop("puzzle_bundle")
         puzzle = kwargs["puzzle"]
@@ -515,14 +522,21 @@ def qfunction_options(func: callable) -> callable:
         "--use-quantize",
         is_flag=True,
         default=False,
-        help="Use quantization (int8).",
+        help="Use quantization (defaults to int8).",
+    )
+    @click.option(
+        "--quant-type",
+        type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+        default="int8",
+        help="Specific AQT quantization configuration to use.",
     )
     @wraps(func)
     def wrapper(*args, **kwargs):
         q_kwargs = map_kwargs_to_pydantic(QFunctionOptions, kwargs)
         q_opts = QFunctionOptions(**q_kwargs)
         use_quantize = kwargs.pop("use_quantize")
-        aqt_cfg = "int8" if use_quantize else None
+        quant_type = kwargs.pop("quant_type")
+        aqt_cfg = quant_type if use_quantize else None
 
         puzzle_bundle = kwargs.pop("puzzle_bundle")
         puzzle = kwargs["puzzle"]
@@ -822,7 +836,13 @@ def dist_heuristic_options(func: callable) -> callable:
         "--use-quantize",
         is_flag=True,
         default=False,
-        help="Use quantization (int8).",
+        help="Use quantization (defaults to int8).",
+    )
+    @click.option(
+        "--quant-type",
+        type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+        default="int8",
+        help="Specific AQT quantization configuration to use.",
     )
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -831,7 +851,8 @@ def dist_heuristic_options(func: callable) -> callable:
         puzzle_name = kwargs["puzzle_name"]
         reset = kwargs["train_options"].reset
         use_quantize = kwargs.pop("use_quantize")
-        aqt_cfg = "int8" if use_quantize else None
+        quant_type = kwargs.pop("quant_type")
+        aqt_cfg = quant_type if use_quantize else None
 
         result = _setup_neural_component(
             puzzle_bundle,
@@ -875,7 +896,13 @@ def dist_qfunction_options(func: callable) -> callable:
         "--use-quantize",
         is_flag=True,
         default=False,
-        help="Use quantization (int8).",
+        help="Use quantization (defaults to int8).",
+    )
+    @click.option(
+        "--quant-type",
+        type=click.Choice(["int8", "int4", "int4_w8a", "int8_w_only"]),
+        default="int8",
+        help="Specific AQT quantization configuration to use.",
     )
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -884,7 +911,8 @@ def dist_qfunction_options(func: callable) -> callable:
         puzzle_name = kwargs["puzzle_name"]
         reset = kwargs["train_options"].reset
         use_quantize = kwargs.pop("use_quantize")
-        aqt_cfg = "int8" if use_quantize else None
+        quant_type = kwargs.pop("quant_type")
+        aqt_cfg = quant_type if use_quantize else None
 
         result = _setup_neural_component(
             puzzle_bundle,

--- a/heuristic/neuralheuristic/heuristic_train.py
+++ b/heuristic/neuralheuristic/heuristic_train.py
@@ -30,6 +30,7 @@ def heuristic_train_builder(
         states: chex.Array,
         target_heuristic: chex.Array,
         weights: chex.Array,
+        key: chex.PRNGKey,
     ):
         # Preprocess during training
         preproc = jax.vmap(preproc_fn)(solveconfigs, states)
@@ -43,6 +44,7 @@ def heuristic_train_builder(
             method=heuristic_model.train_loss,
             loss_type=loss_type,
             loss_args=loss_args,
+            rngs={"params": key},
         )
         new_params = build_new_params_from_updates(heuristic_params, variable_updates)
         loss_value = jnp.mean(per_sample_loss.squeeze() * weights)
@@ -67,7 +69,8 @@ def heuristic_train_builder(
         loss_weights = loss_weights / jnp.mean(loss_weights)
 
         def train_loop(carry, batched_dataset):
-            heuristic_params, opt_state = carry
+            heuristic_params, opt_state, key = carry
+            step_key, key = jax.random.split(key)
             solveconfigs, states, target_heuristic, weights = batched_dataset
             (loss, heuristic_params), grads = jax.value_and_grad(
                 heuristic_train_loss, has_aux=True
@@ -77,18 +80,19 @@ def heuristic_train_builder(
                 states,
                 target_heuristic,
                 weights,
+                step_key,
             )
             if n_devices > 1:
                 grads = jax.lax.psum(grads, axis_name="devices")
             updates, opt_state = optimizer.update(grads, opt_state, params=heuristic_params)
             heuristic_params = optax.apply_updates(heuristic_params, updates)
-            return (heuristic_params, opt_state), loss
+            return (heuristic_params, opt_state, key), loss
 
         # Repeat training loop for replay_ratio iterations with reshuffling
         def replay_loop(carry, replay_key):
             heuristic_params, opt_state = carry
 
-            key_perm_replay, key_fill_replay = jax.random.split(replay_key)
+            key_perm_replay, key_fill_replay, key_train = jax.random.split(replay_key, 3)
             batch_indexs_replay = jnp.concatenate(
                 [
                     jax.random.permutation(key_perm_replay, jnp.arange(data_size)),
@@ -117,9 +121,9 @@ def heuristic_train_builder(
                 jnp.mean(batched_weights_replay, axis=1, keepdims=True) + 1e-8
             )
 
-            (heuristic_params, opt_state), losses = jax.lax.scan(
+            (heuristic_params, opt_state, _), losses = jax.lax.scan(
                 train_loop,
-                (heuristic_params, opt_state),
+                (heuristic_params, opt_state, key_train),
                 (
                     batched_solveconfigs_replay,
                     batched_states_replay,

--- a/heuristic/neuralheuristic/neuralheuristic_base.py
+++ b/heuristic/neuralheuristic/neuralheuristic_base.py
@@ -102,7 +102,6 @@ class NeuralHeuristicBase(Heuristic):
                     self.model_cls,
                     params,
                     sample_input,
-                    self.aqt_cfg,
                     **self.model_kwargs,
                 )
 
@@ -118,7 +117,8 @@ class NeuralHeuristicBase(Heuristic):
             return params
         except Exception as e:
             print(f"Error loading model: {e}")
-            return self.get_new_params()
+            raise e
+            # return self.get_new_params()
 
     def save_model(self, path: str = None, metadata: dict = None):
         path = path or self.path

--- a/heuristic/neuralheuristic/neuralheuristic_base.py
+++ b/heuristic/neuralheuristic/neuralheuristic_base.py
@@ -8,10 +8,12 @@ import numpy as np
 from puxle import Puzzle
 
 from heuristic.heuristic_base import Heuristic
+from neural_util.aqt_utils import convert_to_serving
 from neural_util.basemodel import DistanceHLGModel, DistanceModel, ResMLPModel
 from neural_util.nn_metadata import resolve_model_kwargs
 from neural_util.param_manager import (
     load_params_with_metadata,
+    merge_params,
     save_params_with_metadata,
 )
 from neural_util.util import download_model, is_model_downloaded
@@ -39,6 +41,9 @@ class NeuralHeuristicBase(Heuristic):
 
         resolved_kwargs, nn_args = resolve_model_kwargs(kwargs, saved_metadata.get("nn_args"))
         self.nn_args_metadata = nn_args
+        self.aqt_cfg = kwargs.get("aqt_cfg")
+        self.model_cls = model
+        self.model_kwargs = resolved_kwargs
         self.model = model(**resolved_kwargs)
 
         self.metadata = saved_metadata or {}
@@ -78,6 +83,28 @@ class NeuralHeuristicBase(Heuristic):
                 return self.get_new_params()
             self.metadata = metadata or {}
             self.metadata["nn_args"] = self.nn_args_metadata
+
+            # Initialize full parameters for the current model configuration (includes AQT vars if any)
+            full_params = self.get_new_params()
+
+            # Merge old params into full params. This ensures AQT variables (if missing in old params) are present.
+            params = merge_params(full_params, params)
+
+            if self.aqt_cfg is not None:
+                print("Converting model to serving mode (AQT)...")
+                dummy_solve_config = self.puzzle.SolveConfig.default()
+                dummy_current = self.puzzle.State.default()
+                sample_input = jnp.expand_dims(
+                    self.pre_process(dummy_solve_config, dummy_current), axis=0
+                )
+
+                self.model, params = convert_to_serving(
+                    self.model_cls,
+                    params,
+                    sample_input,
+                    self.aqt_cfg,
+                    **self.model_kwargs,
+                )
 
             dummy_solve_config = self.puzzle.SolveConfig.default()
             dummy_current = self.puzzle.State.default()

--- a/heuristic/neuralheuristic/neuralheuristic_base.py
+++ b/heuristic/neuralheuristic/neuralheuristic_base.py
@@ -112,6 +112,7 @@ class NeuralHeuristicBase(Heuristic):
                 params,
                 jnp.expand_dims(self.pre_process(dummy_solve_config, dummy_current), axis=0),
                 training=False,
+                rngs={"params": jax.random.PRNGKey(0)},
             )  # check if the params are compatible with the model
             self._preloaded_params = None
             return params
@@ -155,7 +156,7 @@ class NeuralHeuristicBase(Heuristic):
         self, params, solve_config: Puzzle.SolveConfig, current: Puzzle.State
     ) -> chex.Array:
         x = self.batched_pre_process(solve_config, current)
-        x = self.model.apply(params, x, training=False)
+        x = self.model.apply(params, x, training=False, rngs={"params": jax.random.PRNGKey(0)})
         x = self.post_process(x)
         return x
 
@@ -178,7 +179,7 @@ class NeuralHeuristicBase(Heuristic):
     ) -> chex.Array:
         x = self.pre_process(solve_config, current)
         x = jnp.expand_dims(x, axis=0)
-        x = self.model.apply(params, x, training=False)
+        x = self.model.apply(params, x, training=False, rngs={"params": jax.random.PRNGKey(0)})
         return self.post_process(x)
 
     @abstractmethod

--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 import os
 
-from cli import cli
-
 # Set default logging level to FATAL (3) to suppress XLA buffer_comparator errors
 # This hides "Difference at X: Y, expected Z" messages during quantization
 os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+
+from cli import cli  # noqa: E402
 
 if __name__ == "__main__":
     cli()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
+import os
 
 from cli import cli
+
+# Set default logging level to FATAL (3) to suppress XLA buffer_comparator errors
+# This hides "Difference at X: Y, expected Z" messages during quantization
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 
 if __name__ == "__main__":
     cli()

--- a/neural_util/aqt_utils.py
+++ b/neural_util/aqt_utils.py
@@ -1,0 +1,83 @@
+import jax
+from aqt.jax.v2 import config as aqt_config
+from aqt.jax.v2.flax import aqt_flax
+
+
+def get_aqt_cfg(aqt_cfg: str = "int8"):
+    if aqt_cfg == "int8":
+        return get_int8_config()
+    else:
+        raise ValueError(f"Invalid AQT configuration: {aqt_cfg}")
+
+
+def get_int8_config():
+    """Returns a fully quantized int8 configuration for AQT."""
+    return aqt_config.fully_quantized(fwd_bits=8, bwd_bits=8)
+
+
+def convert_to_serving(model_cls, params, sample_input, aqt_cfg, **model_kwargs):
+    """
+    Converts a trained model with AQT config to a serving model (freezing quantization stats).
+
+    Args:
+        model_cls: The Flax model class (e.g. ResMLPModel).
+        params: The trained parameters (FrozenDict).
+        sample_input: A sample input array with correct shape and dtype.
+        aqt_cfg: The AQT configuration used during training.
+        **model_kwargs: Additional arguments for model initialization.
+
+    Returns:
+        serving_model: The model instance configured for serving.
+        serving_variables: The variables (params + frozen quant stats) for serving.
+    """
+    # 1. Initialize model in CONVERT mode
+    convert_kwargs = model_kwargs.copy()
+    convert_kwargs["aqt_cfg"] = aqt_cfg
+    convert_kwargs["quant_mode"] = aqt_flax.QuantMode.CONVERT
+
+    convert_model = model_cls(**convert_kwargs)
+
+    # 2. Run forward pass with mutable=True to update quantization statistics
+    # We use training=True/False depending on how we want stats to be collected.
+    # Usually CONVERT mode expects to see data distribution.
+    # We assume 'params' contains the trained weights.
+    # We pass them as the initial variables.
+
+    # Note: If params structure matches what apply expects, we use it.
+    # If params is {'params': ...}, we might need to handle batch_stats if they exist.
+
+    variables = params
+
+    # We run apply. The 'mutable' output will contain the updated variables including quant states.
+    _, converting_variables = convert_model.apply(
+        variables,
+        sample_input,
+        training=True,  # Often needed to activate stats collection if any
+        mutable=True,
+    )
+
+    # 3. Create Serving Model
+    serve_kwargs = model_kwargs.copy()
+    serve_kwargs["aqt_cfg"] = aqt_cfg
+    serve_kwargs["quant_mode"] = aqt_flax.QuantMode.SERVE
+
+    serving_model = model_cls(**serve_kwargs)
+
+    return serving_model, converting_variables
+
+
+def create_serving_fn(model_cls, serving_variables, aqt_cfg, **model_kwargs):
+    """
+    Creates a jit-compiled serving function.
+    """
+    serve_kwargs = model_kwargs.copy()
+    serve_kwargs["aqt_cfg"] = aqt_cfg
+    serve_kwargs["quant_mode"] = aqt_flax.QuantMode.SERVE
+
+    serving_model = model_cls(**serve_kwargs)
+
+    @jax.jit
+    def serve_fn(x):
+        return serving_model.apply(serving_variables, x, training=False)
+
+    return serve_fn

--- a/neural_util/aqt_utils.py
+++ b/neural_util/aqt_utils.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+from typing import Any
 
 import jax
 from aqt.jax.v2 import config as aqt_config
@@ -8,11 +9,14 @@ from aqt.jax.v2.numerics import no_numerics
 from flax.core.frozen_dict import FrozenDict, freeze, unfreeze
 
 
-def get_aqt_cfg(aqt_cfg: str = "int8"):
+def get_aqt_cfg(aqt_cfg: Any = "int8"):
     """
     Returns an AQT configuration based on the provided string.
-    Supported: 'int8', 'int4', 'int4_w8a', 'int8_w_only'
+    If aqt_cfg is already a config object or None, it is returned as is.
+    Supported strings: 'int8', 'int4', 'int4_w8a', 'int8_w_only'
     """
+    if not isinstance(aqt_cfg, str):
+        return aqt_cfg
     if aqt_cfg == "int8":
         return get_int8_config()
     elif aqt_cfg == "int4":

--- a/neural_util/aqt_utils.py
+++ b/neural_util/aqt_utils.py
@@ -78,6 +78,8 @@ def create_serving_fn(model_cls, serving_variables, aqt_cfg, **model_kwargs):
 
     @jax.jit
     def serve_fn(x):
-        return serving_model.apply(serving_variables, x, training=False)
+        return serving_model.apply(
+            serving_variables, x, training=False, rngs={"params": jax.random.PRNGKey(0)}
+        )
 
     return serve_fn

--- a/neural_util/aqt_utils.py
+++ b/neural_util/aqt_utils.py
@@ -4,6 +4,7 @@ import inspect
 import jax
 from aqt.jax.v2 import config as aqt_config
 from aqt.jax.v2.flax import aqt_flax
+from aqt.jax.v2.numerics import no_numerics
 
 
 def get_aqt_cfg(aqt_cfg: str = "int8"):
@@ -39,12 +40,10 @@ def get_int4_weight_int8_act_config():
     """
     cfg = aqt_config.fully_quantized(fwd_bits=8, bwd_bits=8)
     # RHS is typically weights in nn.Dense
-    if cfg.fwd.rhs.tensor is not None:
-        cfg.fwd.rhs.tensor.num_bits = 4
-    if cfg.dlhs.rhs.tensor is not None:
-        cfg.dlhs.rhs.tensor.num_bits = 4
-    if cfg.drhs.rhs.tensor is not None:
-        cfg.drhs.rhs.tensor.num_bits = 4
+    # Update bits in the quantizers
+    cfg.fwd.dg_quantizer.rhs.numerics = cfg.fwd.dg_quantizer.rhs.numerics.replace(bits=4)
+    cfg.dlhs.dg_quantizer.rhs.numerics = cfg.dlhs.dg_quantizer.rhs.numerics.replace(bits=4)
+    cfg.drhs.dg_quantizer.rhs.numerics = cfg.drhs.dg_quantizer.rhs.numerics.replace(bits=4)
     return cfg
 
 
@@ -52,9 +51,9 @@ def get_int8_weight_only_config():
     """Returns a configuration where only weights are quantized to 8-bit."""
     cfg = aqt_config.fully_quantized(fwd_bits=8, bwd_bits=8)
     # LHS is activations, RHS is weights
-    cfg.fwd.lhs.tensor = None
-    cfg.dlhs.lhs.tensor = None
-    cfg.drhs.lhs.tensor = None
+    cfg.fwd.dg_quantizer.lhs.numerics = no_numerics.NoNumerics()
+    cfg.dlhs.dg_quantizer.lhs.numerics = no_numerics.NoNumerics()
+    cfg.drhs.dg_quantizer.lhs.numerics = no_numerics.NoNumerics()
     return cfg
 
 

--- a/neural_util/basemodel/hlgresmlp.py
+++ b/neural_util/basemodel/hlgresmlp.py
@@ -1,10 +1,10 @@
-import functools
 from typing import Any
 
 import jax.numpy as jnp
 from aqt.jax.v2.flax import aqt_flax
 from flax import linen as nn
 
+from neural_util.aqt_utils import build_aqt_dot_general
 from neural_util.basemodel.base import DistanceHLGModel
 from neural_util.modules import (
     DEFAULT_NORM_FN,
@@ -71,11 +71,7 @@ class HLGResMLPModel(DistanceHLGModel):
         aqt_dg = None
         if self.aqt_cfg is not None:
             mode = self.quant_mode if self.quant_mode is not None else aqt_flax.QuantMode.TRAIN
-            aqt_dg = functools.partial(
-                aqt_flax.AqtDotGeneral,
-                self.aqt_cfg,
-                rhs_quant_mode=mode,
-            )
+            aqt_dg = build_aqt_dot_general(self.aqt_cfg, mode)
 
         self.initial_mlp = (
             Swiglu(self.initial_dim, norm_fn=self.norm_fn, dtype=DTYPE, dot_general_cls=aqt_dg)

--- a/neural_util/basemodel/resmlp.py
+++ b/neural_util/basemodel/resmlp.py
@@ -1,9 +1,9 @@
-import functools
 from typing import Any
 
 from aqt.jax.v2.flax import aqt_flax
 from flax import linen as nn
 
+from neural_util.aqt_utils import build_aqt_dot_general
 from neural_util.basemodel.base import DistanceModel
 from neural_util.modules import (
     DEFAULT_NORM_FN,
@@ -34,11 +34,7 @@ class ResMLPModel(DistanceModel):
         aqt_dg = None
         if self.aqt_cfg is not None:
             mode = self.quant_mode if self.quant_mode is not None else aqt_flax.QuantMode.TRAIN
-            aqt_dg = functools.partial(
-                aqt_flax.AqtDotGeneral,
-                self.aqt_cfg,
-                rhs_quant_mode=mode,
-            )
+            aqt_dg = build_aqt_dot_general(self.aqt_cfg, mode)
 
         if self.use_swiglu:
             x = Swiglu(self.initial_dim, norm_fn=self.norm_fn, dtype=DTYPE, dot_general_cls=aqt_dg)(

--- a/neural_util/basemodel/resmlp.py
+++ b/neural_util/basemodel/resmlp.py
@@ -1,3 +1,7 @@
+import functools
+from typing import Any
+
+from aqt.jax.v2.flax import aqt_flax
 from flax import linen as nn
 
 from neural_util.basemodel.base import DistanceModel
@@ -22,20 +26,35 @@ class ResMLPModel(DistanceModel):
     use_swiglu: bool = False
     hidden_node_multiplier: int = 1
     tail_head_precision: int = 0
+    aqt_cfg: Any = None
+    quant_mode: Any = None
 
     @nn.compact
     def __call__(self, x, training=False):
+        aqt_dg = None
+        if self.aqt_cfg is not None:
+            mode = self.quant_mode if self.quant_mode is not None else aqt_flax.QuantMode.TRAIN
+            aqt_dg = functools.partial(
+                aqt_flax.AqtDotGeneral,
+                self.aqt_cfg,
+                rhs_quant_mode=mode,
+            )
+
         if self.use_swiglu:
-            x = Swiglu(self.initial_dim, norm_fn=self.norm_fn, dtype=DTYPE)(x, training)
+            x = Swiglu(self.initial_dim, norm_fn=self.norm_fn, dtype=DTYPE, dot_general_cls=aqt_dg)(
+                x, training
+            )
             if self.resblock_fn != PreActivationResBlock:
-                x = Swiglu(self.hidden_dim, norm_fn=self.norm_fn, dtype=DTYPE)(x, training)
+                x = Swiglu(
+                    self.hidden_dim, norm_fn=self.norm_fn, dtype=DTYPE, dot_general_cls=aqt_dg
+                )(x, training)
             else:
-                x = nn.Dense(self.hidden_dim, dtype=DTYPE)(x)
+                x = nn.Dense(self.hidden_dim, dtype=DTYPE, dot_general_cls=aqt_dg)(x)
         else:
-            x = nn.Dense(self.initial_dim, dtype=DTYPE)(x)
+            x = nn.Dense(self.initial_dim, dtype=DTYPE, dot_general_cls=aqt_dg)(x)
             x = self.norm_fn(x, training, dtype=DTYPE)
             x = self.activation(x)
-            x = nn.Dense(self.hidden_dim, dtype=DTYPE)(x)
+            x = nn.Dense(self.hidden_dim, dtype=DTYPE, dot_general_cls=aqt_dg)(x)
             if self.resblock_fn != PreActivationResBlock:
                 x = self.norm_fn(x, training, dtype=DTYPE)
                 x = self.activation(x)
@@ -46,6 +65,7 @@ class ResMLPModel(DistanceModel):
                 hidden_N=self.hidden_N,
                 activation=self.activation,
                 use_swiglu=self.use_swiglu,
+                dot_general_cls=aqt_dg,
             )(x, training)
         for _ in range(self.tail_head_precision):
             x = self.resblock_fn(
@@ -56,12 +76,16 @@ class ResMLPModel(DistanceModel):
                 use_swiglu=self.use_swiglu,
                 dtype=HEAD_DTYPE,
                 param_dtype=HEAD_DTYPE,
+                dot_general_cls=aqt_dg,
             )(x, training)
         if self.resblock_fn == PreActivationResBlock:
             x = self.norm_fn(x, training, dtype=HEAD_DTYPE)
             x = self.activation(x)
         x = x.astype(HEAD_DTYPE)
         x = nn.Dense(
-            self.action_size, dtype=HEAD_DTYPE, kernel_init=nn.initializers.normal(stddev=0.01)
+            self.action_size,
+            dtype=HEAD_DTYPE,
+            kernel_init=nn.initializers.normal(stddev=0.01),
+            dot_general_cls=aqt_dg,
         )(x)
         return x

--- a/neural_util/nn_metadata.py
+++ b/neural_util/nn_metadata.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple
 
+from .aqt_utils import get_aqt_cfg
 from .modules import (
     ACTIVATION_FN_REGISTRY,
     NORM_FN_REGISTRY,
@@ -43,6 +44,8 @@ def prepare_model_kwargs(raw_kwargs: Dict[str, Any]) -> Dict[str, Any]:
         kwargs["resblock_fn"] = get_resblock_fn(kwargs["resblock_fn"])
     if "use_swiglu" in kwargs:
         kwargs["use_swiglu"] = bool(kwargs["use_swiglu"])
+    if "aqt_cfg" in kwargs:
+        kwargs["aqt_cfg"] = get_aqt_cfg(kwargs["aqt_cfg"])
     return kwargs
 
 
@@ -64,6 +67,8 @@ def serialize_nn_args(model_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """
     encoded = {}
     for key, value in model_kwargs.items():
+        if key in ["aqt_cfg", "quant_mode"]:
+            continue
         if key == "norm_fn":
             encoded[key] = _callable_to_key(value, NORM_FN_REGISTRY, "batch")
         elif key == "activation":

--- a/qfunction/neuralq/neuralq_base.py
+++ b/qfunction/neuralq/neuralq_base.py
@@ -7,10 +7,12 @@ import jax.numpy as jnp
 import numpy as np
 from puxle import Puzzle
 
+from neural_util.aqt_utils import convert_to_serving
 from neural_util.basemodel import DistanceHLGModel, DistanceModel, ResMLPModel
 from neural_util.nn_metadata import resolve_model_kwargs
 from neural_util.param_manager import (
     load_params_with_metadata,
+    merge_params,
     save_params_with_metadata,
 )
 from neural_util.util import download_model, is_model_downloaded
@@ -40,6 +42,9 @@ class NeuralQFunctionBase(QFunction):
 
         resolved_kwargs, nn_args = resolve_model_kwargs(kwargs, saved_metadata.get("nn_args"))
         self.nn_args_metadata = nn_args
+        self.aqt_cfg = kwargs.get("aqt_cfg")
+        self.model_cls = model
+        self.model_kwargs = {**resolved_kwargs, "action_size": self.action_size}
         self.model = model(self.action_size, **resolved_kwargs)
         self.metadata = saved_metadata or {}
         self.metadata["nn_args"] = self.nn_args_metadata
@@ -77,6 +82,28 @@ class NeuralQFunctionBase(QFunction):
                 return self.get_new_params()
             self.metadata = metadata or {}
             self.metadata["nn_args"] = self.nn_args_metadata
+
+            # Initialize full parameters for the current model configuration (includes AQT vars if any)
+            full_params = self.get_new_params()
+
+            # Merge old params into full params. This ensures AQT variables (if missing in old params) are present.
+            params = merge_params(full_params, params)
+
+            if self.aqt_cfg is not None:
+                print("Converting model to serving mode (AQT)...")
+                dummy_solve_config = self.puzzle.SolveConfig.default()
+                dummy_current = self.puzzle.State.default()
+                sample_input = jnp.expand_dims(
+                    self.pre_process(dummy_solve_config, dummy_current), axis=0
+                )
+
+                self.model, params = convert_to_serving(
+                    self.model_cls,
+                    params,
+                    sample_input,
+                    self.aqt_cfg,
+                    **self.model_kwargs,
+                )
 
             dummy_solve_config = self.puzzle.SolveConfig.default()
             dummy_current = self.puzzle.State.default()

--- a/qfunction/neuralq/neuralq_base.py
+++ b/qfunction/neuralq/neuralq_base.py
@@ -111,6 +111,7 @@ class NeuralQFunctionBase(QFunction):
                 params,
                 jnp.expand_dims(self.pre_process(dummy_solve_config, dummy_current), axis=0),
                 training=False,
+                rngs={"params": jax.random.PRNGKey(0)},
             )  # check if the params are compatible with the model
             self._preloaded_params = None
             return params
@@ -154,7 +155,7 @@ class NeuralQFunctionBase(QFunction):
         self, params, solve_config: Puzzle.SolveConfig, current: Puzzle.State
     ) -> chex.Array:
         x = self.batched_pre_process(solve_config, current)
-        x = self.model.apply(params, x, training=False)
+        x = self.model.apply(params, x, training=False, rngs={"params": jax.random.PRNGKey(0)})
         x = self.post_process(x)
         return x
 
@@ -175,7 +176,7 @@ class NeuralQFunctionBase(QFunction):
     ) -> chex.Array:
         x = self.pre_process(solve_config, current)
         x = jnp.expand_dims(x, axis=0)
-        x = self.model.apply(params, x, training=False)
+        x = self.model.apply(params, x, training=False, rngs={"params": jax.random.PRNGKey(0)})
         return self.post_process(x)
 
     @abstractmethod

--- a/qfunction/neuralq/neuralq_base.py
+++ b/qfunction/neuralq/neuralq_base.py
@@ -101,7 +101,6 @@ class NeuralQFunctionBase(QFunction):
                     self.model_cls,
                     params,
                     sample_input,
-                    self.aqt_cfg,
                     **self.model_kwargs,
                 )
 
@@ -117,7 +116,8 @@ class NeuralQFunctionBase(QFunction):
             return params
         except Exception as e:
             print(f"Error loading model: {e}")
-            return self.get_new_params()
+            raise e
+            # return self.get_new_params()
 
     def save_model(self, path: str = None, metadata: dict = None):
         path = path or self.path

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ chex
 dm_pix
 dm-haiku
 huggingface_hub
+aqtp
 flax
 optax @ git+https://github.com/tinker495/optax.git@feature/add-normuon
 termcolor

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -10,6 +10,7 @@ chex
 dm_pix
 dm-haiku
 huggingface_hub
+aqtp
 flax
 optax @ git+https://github.com/tinker495/optax.git@dev/merge-all-custom
 termcolor

--- a/requirements_tpu.txt
+++ b/requirements_tpu.txt
@@ -11,6 +11,7 @@ chex
 dm_pix
 dm-haiku
 huggingface_hub
+aqtp
 flax
 optax @ git+https://github.com/tinker495/optax.git@feature/add-normuon
 termcolor


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces end-to-end AQT quantization for neural heuristics and Q-functions, with CLI control and model/runtime wiring.
> 
> - Adds `--use-quantize` and `--quant-type {int8,int4,int4_w8a,int8_w_only}` to benchmark and (dist) heuristic/Q-function CLIs; plumbs `aqt_cfg` through loaders and options
> - New `neural_util/aqt_utils.py` for building AQT DotGeneral and converting trained models to SERVE mode; integrates into model load paths
> - Updates `ResMLPModel`/`HLGResMLPModel` and modules to accept `aqt_cfg`/`quant_mode` and pass `dot_general_cls` to `nn.Dense`
> - Enhances param loading with `merge_params` to add AQT vars; attaches runtime metadata incl. `aqt_cfg` and quant-aware `param_stats`
> - Training/inference: pass RNGs to `.apply` and losses; fix training scans to thread keys
> - CLI benchmark commands and options now attach `aqt_cfg` in runtime metadata; suppress XLA noise via `TF_CPP_MIN_LOG_LEVEL=3`
> - Dependencies: add `aqtp` to requirements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3f803ccb01f5d87ec76f3957d1ffbf9b11a4681. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->